### PR TITLE
Feat: Added optional input targeting for ToggleMute

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
 enum Command {
     ToggleStream,
     ToggleRecord,
-    ToggleMute,
+    ToggleMute { input: Option<String> },
     SetScene { scene: String },
 }
 
@@ -98,12 +98,23 @@ ERROR message:
                 .await
                 .context("toggle recording")?;
         }
-        Command::ToggleMute => {
-            client
-                .inputs()
-                .toggle_mute("Mic/Aux")
-                .await
-                .context("toggle-mute Mic/Aux")?;
+        Command::ToggleMute { input } => {
+            match input {
+                Some(target) => {
+                    client
+                        .inputs()
+                        .toggle_mute(&target)
+                        .await
+                        .context("toggle-input-mute {target}")?;
+                },
+                None => {
+                    client
+                        .inputs()
+                        .toggle_mute("Mic/Aux")
+                        .await
+                        .context("toggle-input-mute Mic/Aux")?;
+                }
+            }
         }
         Command::SetScene { scene } => {
             client


### PR DESCRIPTION
A load of word waffle, but this change allows you to optionally specify which input you want to toggle, which is very useful since renaming and multiple audio inputs are common in streaming. Requires no changes to existing configs and doesn't break anything.

Hope you're having a good day, thanks for doing most of the community legwork in Rust!

P.S. On a loosely-related note, Windows users should take note that the program apparently expects the `websocket-token` file in `AppData\Roaming\obs-do\config` rather than `C:\Users\<user>\.config\obs-do\`