### PR TITLE
Feat: Added optional input targeting for ToggleMute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+Forked from jonhoo after seeing that one or two basic additions could be made, then got a little carried away.
+This fork adds in:
+--optional targeting for the ToggleMute command
+--ToggleInputFade, which actively fades between volumes over a set amount of time.
+--TBD?
+
+---
+
 [![Crates.io](https://img.shields.io/crates/v/obs-do.svg)](https://crates.io/crates/guardian)
 [![codecov](https://codecov.io/gh/jonhoo/obs-do/branch/main/graph/badge.svg?token=QOXMTH9TSA)](https://codecov.io/gh/jonhoo/guardian)
 [![Dependency status](https://deps.rs/repo/github/jonhoo/obs-do/status.svg)](https://deps.rs/repo/github/jonhoo/guardian)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-Forked from jonhoo after seeing that one or two basic additions could be made, then got a little carried away.
+Forked from jonhoo after seeing that one or two basic additions could be made, then got a little carried away.   
 This fork adds in:
---optional targeting for the ToggleMute command
---ToggleInputFade, which actively fades between volumes over a set amount of time.
---TBD?
+
+--optional targeting for the ToggleMute command   
+--ToggleInputFade, which actively fades between volumes over a set amount of time.   
+--TBD?   
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,14 +105,14 @@ ERROR message:
                         .inputs()
                         .toggle_mute(&target)
                         .await
-                        .context("toggle-input-mute {target}")?;
+                        .context("toggle-mute {target}")?;
                 },
                 None => {
                     client
                         .inputs()
                         .toggle_mute("Mic/Aux")
                         .await
-                        .context("toggle-input-mute Mic/Aux")?;
+                        .context("toggle-mute Mic/Aux")?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
 enum Command {
     ToggleStream,
     ToggleRecord,
-    ToggleMute,
+    ToggleMute { input: Option<String> },
     SetScene { scene: String },
 }
 
@@ -98,12 +98,23 @@ ERROR message:
                 .await
                 .context("toggle recording")?;
         }
-        Command::ToggleMute => {
-            client
-                .inputs()
-                .toggle_mute("Mic/Aux")
-                .await
-                .context("toggle-mute Mic/Aux")?;
+        Command::ToggleMute { input } => {
+            match input {
+                Some(target) => {
+                    client
+                        .inputs()
+                        .toggle_mute(&target)
+                        .await
+                        .context("toggle-input-mute {target}")?;
+                },
+                None => {
+                    client
+                        .inputs()
+                        .toggle_mute("Mic/Aux")
+                        .await
+                        .context("toggle-input-mute Mic/Aux")?;
+                }
+            }
         }
         Command::SetScene { scene } => {
             client


### PR DESCRIPTION
A load of word waffle, but this change allows you to optionally specify which input you want to toggle, which is very useful since renaming and multiple audio inputs are common in streaming. Requires no changes to existing configs and doesn't break anything.

Hope you're having a good day, thanks for doing most of the community legwork in Rust!

P.S. On a loosely-related note, Windows users should take note that the program apparently expects the websocket-token file in AppData\Roaming\obs-do\config rather than C:\Users\<user>\.config\obs-do\
