### PR TITLE
Feat - Added ToggleMute optional targeting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ struct Args {
 enum Command {
     ToggleStream,
     ToggleRecord,
+    /// Takes an input target and mutes it. If no target is provided, mutes 'Mic/Aux' instead.
     ToggleMute { input: Option<String> },
     SetScene { scene: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
 enum Command {
     ToggleStream,
     ToggleRecord,
-    ToggleMute,
+    ToggleMute { input: Option<String> },
     SetScene { scene: String },
 }
 
@@ -98,12 +98,23 @@ ERROR message:
                 .await
                 .context("toggle recording")?;
         }
-        Command::ToggleMute => {
-            client
-                .inputs()
-                .toggle_mute("Mic/Aux")
-                .await
-                .context("toggle-mute Mic/Aux")?;
+        Command::ToggleMute { input } => {
+            match input {
+                Some(input) => {
+                    client
+                        .inputs()
+                        .toggle_mute(&input)
+                        .await
+                        .context(format!("toggle-mute {input}"))?;
+                },
+                None => {
+                    client
+                        .inputs()
+                        .toggle_mute("Mic/Aux")
+                        .await
+                        .context("toggle-mute Mic/Aux")?;
+                }
+            }
         }
         Command::SetScene { scene } => {
             client


### PR DESCRIPTION
I think I got it now :p Thanks for the patience.

Added in the ability to target a specific input with ToggleMute.
Target is optional; if none is supplied, mutes 'Mic/Aux' instead.
Shouldn't break existing scripts or implementations.
Added summary doc comment for --help.