### PR TITLE
Feat - Added SetVolume command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use directories::ProjectDirs;
-use obws::Client;
+use obws::{Client, requests::inputs::Volume};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -16,6 +16,11 @@ enum Command {
     ToggleRecord,
     ToggleMute { input: Option<String> },
     SetScene { scene: String },
+    SetVolume { 
+        input: String,
+        #[arg(allow_hyphen_values = true)]
+        target_vol: String 
+    },
 }
 
 #[tokio::main]
@@ -122,6 +127,30 @@ ERROR message:
                 .set_current_program_scene(&scene)
                 .await
                 .with_context(|| format!("set-scene {scene}"))?;
+        }
+        Command::SetVolume { input, target_vol } => {
+            let eval_target = target_vol.to_lowercase();
+            let final_vol: Volume;
+
+            if eval_target.contains('%') {
+                final_vol = Volume::Mul(
+                    (eval_target.split('%').collect::<String>().parse::<f32>().unwrap()) / 100.0
+                );
+            } else if eval_target.contains("db") {
+                final_vol = Volume::Db(
+                    eval_target.split("db").collect::<String>().parse::<f32>().unwrap()
+                );
+            } else {
+                final_vol = Volume::Mul(
+                    (eval_target.parse::<f32>().unwrap()) / 100.0
+                );
+            }
+
+            client
+                .inputs()
+                .set_volume(&input, final_vol)
+                .await
+                .context(format!("set-volume {input}"))?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ enum Command {
     ToggleRecord,
     ToggleMute { input: Option<String> },
     SetScene { scene: String },
+    /// Sets volume for input to specified volume, in db or %. If no unit is provided, defaults to %.
     SetVolume { 
         input: String,
         #[arg(allow_hyphen_values = true)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,12 +105,23 @@ ERROR message:
                 .await
                 .context("toggle recording")?;
         }
-        Command::ToggleMute => {
-            client
-                .inputs()
-                .toggle_mute("Mic/Aux")
-                .await
-                .context("toggle-mute Mic/Aux")?;
+        Command::ToggleMute { input } => {
+            match input {
+                Some(input) => {
+                    client
+                        .inputs()
+                        .toggle_mute(&input)
+                        .await
+                        .context(format!("toggle-mute {input}"))?;
+                },
+                None => {
+                    client
+                        .inputs()
+                        .toggle_mute("Mic/Aux")
+                        .await
+                        .context("toggle-mute Mic/Aux")?;
+                }
+            }
         }
         Command::SetScene { scene } => {
             client

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
 enum Command {
     ToggleStream,
     ToggleRecord,
-    ToggleMute { input: Option<String> },
+    ToggleMute,
     SetScene { scene: String },
     /// Sets volume for input to specified volume, in db or %. If no unit is provided, defaults to %.
     SetVolume { 
@@ -104,23 +104,12 @@ ERROR message:
                 .await
                 .context("toggle recording")?;
         }
-        Command::ToggleMute { input } => {
-            match input {
-                Some(input) => {
-                    client
-                        .inputs()
-                        .toggle_mute(&input)
-                        .await
-                        .context(format!("toggle-mute {input}"))?;
-                },
-                None => {
-                    client
-                        .inputs()
-                        .toggle_mute("Mic/Aux")
-                        .await
-                        .context("toggle-mute Mic/Aux")?;
-                }
-            }
+        Command::ToggleMute => {
+            client
+                .inputs()
+                .toggle_mute("Mic/Aux")
+                .await
+                .context("toggle-mute Mic/Aux")?;
         }
         Command::SetScene { scene } => {
             client


### PR DESCRIPTION
Added SetVolume command for <you guessed it> directly setting the volume of a given input.
Takes either a raw decibel value or a percentage. If no unit is provided, interprets volume as percentage.
Added doc comment for --help.